### PR TITLE
fixing bugs in Tello 

### DIFF
--- a/drone/tello/README.md
+++ b/drone/tello/README.md
@@ -95,7 +95,7 @@ This is the same functionality as step04, but instead of using Metal Gobot now w
 
 Now it is time for free flight, controlled by you, the human pilot. Plug in the DS4 or DS3 controller to your computer. The controls are as follows:
 
-* Triangle    - Takeoff
+* Start    - Takeoff
 * X           - Land
 * Left stick  - altitude
 * Right stick - direction

--- a/drone/tello/step4/main.go
+++ b/drone/tello/step4/main.go
@@ -38,7 +38,7 @@ func main() {
 
 		if time.Since(start) > 2*time.Second {
 			flightPattern.Do(func() {
-				go flyWithFlip()
+				go flyWithFlips()
 			})
 		}
 

--- a/drone/tello/step5/main.go
+++ b/drone/tello/step5/main.go
@@ -132,22 +132,22 @@ func configureStickEvents(stick *joystick.Driver) {
 	})
 
 	stick.On(joystick.LeftX, func(data interface{}) {
-		val := float64(data.(int16))
+		val := float64(data.(int))
 		leftX.Store(val)
 	})
 
 	stick.On(joystick.LeftY, func(data interface{}) {
-		val := float64(data.(int16))
+		val := float64(data.(int))
 		leftY.Store(val)
 	})
 
 	stick.On(joystick.RightX, func(data interface{}) {
-		val := float64(data.(int16))
+		val := float64(data.(int))
 		rightX.Store(val)
 	})
 
 	stick.On(joystick.RightY, func(data interface{}) {
-		val := float64(data.(int16))
+		val := float64(data.(int))
 		rightY.Store(val)
 	})
 }

--- a/drone/tello/step6/main.go
+++ b/drone/tello/step6/main.go
@@ -157,22 +157,22 @@ func configureStickEvents(stick *joystick.Driver) {
 	})
 
 	stick.On(joystick.LeftX, func(data interface{}) {
-		val := float64(data.(int16))
+		val := float64(data.(int))
 		leftX.Store(val)
 	})
 
 	stick.On(joystick.LeftY, func(data interface{}) {
-		val := float64(data.(int16))
+		val := float64(data.(int))
 		leftY.Store(val)
 	})
 
 	stick.On(joystick.RightX, func(data interface{}) {
-		val := float64(data.(int16))
+		val := float64(data.(int))
 		rightX.Store(val)
 	})
 
 	stick.On(joystick.RightY, func(data interface{}) {
-		val := float64(data.(int16))
+		val := float64(data.(int))
 		rightY.Store(val)
 	})
 }


### PR DESCRIPTION
- **Step 4** Drone flip function is being miscalled as `flyWithFlip()` should be `flyWithFlips()`
- **Step 5** and **Step 6** we get a `panic: interface conversion: interface {} is int, not int16`. Changing the corresponding type conversions.
- Takeoff is using the `Start` button. Not the `Triangle` button.
